### PR TITLE
Close container of disconnected players

### DIFF
--- a/src/main/java/de/dosmike/sponge/vshop/EventListeners.java
+++ b/src/main/java/de/dosmike/sponge/vshop/EventListeners.java
@@ -134,6 +134,8 @@ public class EventListeners {
                 .map(NPCguard::getPreparator)
                 .map(InvPrep::getMenu)
                 .forEach(m->m.clearPlayerState(event.getTargetEntity().getUniqueId()));
+
+        Utilities.openShops.remove(event.getTargetEntity().getUniqueId());
     }
 
     @Listener


### PR DESCRIPTION
If a player disconnects or force closes the client while the trader inventory is open, it has to be closed on the server too.